### PR TITLE
Navbar position fixed under 768px

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -165,7 +165,15 @@ body > footer li a{
 }
 
 
+/*
 
+@media screen and (max-width: 768px) {
+	.navbar {
+		position: fixed;
+	}
+}
+
+*/
 
 
 


### PR DESCRIPTION
Media queries under 768px added to style.css in order to correct the navbar position in responsive

Related issue: #3

**Description**

The problem was : under 768px, the navbar was hidden.